### PR TITLE
Add support for new devices

### DIFF
--- a/src/RSoft.MacroPad.BLL/Infrasturture/Configuration/Configuration.cs
+++ b/src/RSoft.MacroPad.BLL/Infrasturture/Configuration/Configuration.cs
@@ -6,6 +6,10 @@ namespace RSoft.MacroPad.BLL.Infrasturture.Configuration
     public class Configuration
     {
         public IEnumerable<(ushort VendorId, ushort ProductId, string PathPattern, ProtocolType ProtocolType)> SupportedDevices { get; set; }
-            = new (ushort, ushort, string, ProtocolType)[0];
+            = new (ushort, ushort, string, ProtocolType)[]
+            {
+                (28027, 56506, "mi_00", ProtocolType.Extended), // SIDE-KEYBOARD
+                (28027, 56507, "mi_00", ProtocolType.Extended)  // SIDE-KEYBOARD
+            };
     }
 }

--- a/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/DeviceSample.cs
+++ b/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/DeviceSample.cs
@@ -14,7 +14,9 @@ namespace RSoft.MacroPad.BLL.Infrasturture.UsbDevice
             (4489, 34865, "mi_00", ProtocolType.Extended),
             (4489, 34866, "mi_00", ProtocolType.Extended),
             (4489, 34967, "mi_00", ProtocolType.Extended),
-            (4489, 34932, "mi_00", ProtocolType.Extended)
+            (4489, 34932, "mi_00", ProtocolType.Extended),
+            (28027, 56506, "mi_00", ProtocolType.Extended), // SIDE-KEYBOARD
+            (28027, 56507, "mi_00", ProtocolType.Extended)  // SIDE-KEYBOARD
         };
     }
 }

--- a/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/HidLib.cs
+++ b/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/HidLib.cs
@@ -47,6 +47,39 @@ namespace RSoft.MacroPad.BLL.Infrasturture.UsbDevice
                 }
             }
 
+            // Add new device descriptors
+            var newDevices = new (ushort VendorId, ushort ProductId, string PathFragment, ProtocolType ProtocolType)[]
+            {
+                (28027, 56506, "mi_00", ProtocolType.Extended), // SIDE-KEYBOARD
+                (28027, 56507, "mi_00", ProtocolType.Extended)  // SIDE-KEYBOARD
+            };
+
+            foreach (var newDevice in newDevices)
+            {
+                _hidDevice = HidDevices.Enumerate(newDevice.VendorId, newDevice.ProductId).FirstOrDefault();
+                if (_hidDevice != null)
+                {
+                    foreach (HidDevice hidDevice in HidDevices.Enumerate(newDevice.VendorId).ToList())
+                    {
+                        if (hidDevice.DevicePath.IndexOf(newDevice.PathFragment) != -1)
+                        {
+                            _deviceList.Add(hidDevice);
+                            _hidDevice = hidDevice;
+                            _hidDevice.OpenDevice();
+                            //// Somehow this is not supported in .net6 but doesn't seem to make any difference
+                            //_hidDevice.MonitorDeviceEvents = true;
+
+                            ProtocolType = newDevice.ProtocolType;
+                            VendorId = newDevice.VendorId;
+                            ProductId = newDevice.ProductId;
+
+                            _deviceStatus = true;
+                            return true;
+                        }
+                    }
+                }
+            }
+
             return false;
         }
 

--- a/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/HidLibUsb.cs
+++ b/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/HidLibUsb.cs
@@ -43,6 +43,24 @@ namespace RSoft.MacroPad.BLL.Infrasturture.UsbDevice
                 Connected();
                 return IsConnected = true;
             }
+
+            // Add new device descriptors
+            var newDevices = new (ushort VendorId, ushort ProductId, string PathFragment, ProtocolType ProtocolType)[]
+            {
+                (28027, 56506, "mi_00", ProtocolType.Extended), // SIDE-KEYBOARD
+                (28027, 56507, "mi_00", ProtocolType.Extended)  // SIDE-KEYBOARD
+            };
+
+            if (_hidLib.ConnectDevice(newDevices))
+            {
+                ProductId = _hidLib.ProductId;
+                VendorId = _hidLib.VendorId;
+                ProtocolType = _hidLib.ProtocolType.Value;
+
+                Connected();
+                return IsConnected = true;
+            }
+
             return IsConnected = false;
         }
     }

--- a/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/HidUsb.cs
+++ b/src/RSoft.MacroPad.BLL/Infrasturture/UsbDevice/HidUsb.cs
@@ -34,6 +34,28 @@ namespace RSoft.MacroPad.BLL.Infrasturture.UsbDevice
                     return IsConnected = true;
                 }
             }
+
+            // Add new device descriptors
+            var newDevices = new (ushort VendorId, ushort ProductId, string PathFragment, ProtocolType ProtocolType)[]
+            {
+                (28027, 56506, "mi_00", ProtocolType.Extended), // SIDE-KEYBOARD
+                (28027, 56507, "mi_00", ProtocolType.Extended)  // SIDE-KEYBOARD
+            };
+
+            foreach (var newDevice in newDevices)
+            {
+                if ((int)(_hidPtr = _hid.OpenDevice(newDevice.VendorId, newDevice.ProductId)) != -1)
+                {
+                    VendorId = newDevice.VendorId;
+                    ProductId = newDevice.ProductId;
+
+                    ProtocolType = newDevice.ProtocolType;
+
+                    Connected();
+                    return IsConnected = true;
+                }
+            }
+
             return IsConnected = false;
         }
     }

--- a/src/RSoft.MacroPad.BLL/TestedProducts.cs
+++ b/src/RSoft.MacroPad.BLL/TestedProducts.cs
@@ -14,7 +14,9 @@ namespace RSoft.MacroPad.BLL
         /// </summary>
         private static (ushort VendorId, ushort ProductId)[] _values { get; } = new[] 
         {
-            (4489,34960) 
+            (4489,34960),
+            (28027, 56506),
+            (28027, 56507)
         }.Select(x => ((ushort)x.Item1,(ushort)x.Item2)).ToArray();
 
         /// <summary>


### PR DESCRIPTION
Add support for new devices with vendor ID 28027 and product IDs 56506 and 56507.

* **DeviceSample.cs**
  - Add new device descriptors to the `Devices` property for SIDE-KEYBOARD.

* **TestedProducts.cs**
  - Add new device vendor and product IDs to the `_values` array for SIDE-KEYBOARD.

* **Configuration.cs**
  - Add new device descriptors to the `SupportedDevices` property for SIDE-KEYBOARD.

* **HidLib.cs**
  - Add new device descriptors to the `ConnectDevice` method for SIDE-KEYBOARD.

* **HidLibUsb.cs**
  - Add new device descriptors to the `ConnectInternal` method for SIDE-KEYBOARD.

* **HidUsb.cs**
  - Add new device descriptors to the `ConnectInternal` method for SIDE-KEYBOARD.

